### PR TITLE
fix a set of issues CLI to work correctly

### DIFF
--- a/src/cli/cli.csproj
+++ b/src/cli/cli.csproj
@@ -26,6 +26,7 @@
 
     <ItemGroup>
       <PackageReference Include="CommandLineParser" Version="2.6.0" />
+      <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.0" />
       <PackageReference Include="Serilog" Version="2.9.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
       <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
@@ -34,6 +35,7 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
+      <PackageReference Include="YamlDotNet" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/cli/configuration/RegistryConfiguration.cs
+++ b/src/cli/configuration/RegistryConfiguration.cs
@@ -1,0 +1,9 @@
+using core.scanners;
+
+namespace cli.configuration
+{
+    public class RegistryConfiguration
+    {
+        public RegistryCredentials[] Registries { get; set; }
+    }
+}

--- a/src/cli/configuration/RegistryConfigurationParser.cs
+++ b/src/cli/configuration/RegistryConfigurationParser.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using Serilog;
+
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+using YamlDotNet.Serialization.TypeResolvers;
+
+namespace cli.configuration
+{
+    public class RegistryConfigurationParser
+    {
+        private static readonly ILogger Logger = Log.ForContext<RegistryConfigurationParser>();
+        private static readonly IDeserializer Deserializer;
+
+        private readonly Lazy<RegistryConfiguration> registryConfig;
+
+        static RegistryConfigurationParser()
+        {
+            Deserializer = new DeserializerBuilder()
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .WithTypeResolver(new DynamicTypeResolver())
+                .WithTagMapping("!registries", typeof(RegistryConfiguration))
+                .Build();
+        }
+
+        public RegistryConfigurationParser(string configFilePath)
+        {
+            if (!File.Exists(configFilePath))
+            {
+                Logger.Fatal("Container registry config file does not exist at {ConfigFilePath}", configFilePath);
+                throw new Exception($"Container registry config file does not exist at {configFilePath}");
+            }
+
+            this.registryConfig = new Lazy<RegistryConfiguration>(() => Init(configFilePath));
+        }
+
+        public RegistryConfiguration Get()
+        {
+            return this.registryConfig.Value;
+        }
+
+        private static RegistryConfiguration Parse(string input)
+        {
+            return Deserializer.Deserialize<RegistryConfiguration>(input);
+        }
+
+        private static RegistryConfiguration Init(string configFilePath)
+        {
+            var configString = File.ReadAllText(configFilePath);
+
+            return Parse(configString);
+        }
+    }
+}

--- a/src/cli/options/GlobalOptions.cs
+++ b/src/cli/options/GlobalOptions.cs
@@ -4,7 +4,7 @@ namespace cli.options
 {
     public abstract class GlobalOptions
     {
-        [Option('k', "kubeConfigPath", Required = false, HelpText = "File path of Kube Config file")]
+        [Option('k', "kubeConfigPath", Required = false, SetName = "KubeConfigPath", HelpText = "File path of Kube Config file")]
         public string KubeConfigPath { get; set; }
 
         [Option('e', "exporter", Required = true, HelpText = "Exporter type (e.g, File)")]
@@ -21,5 +21,8 @@ namespace cli.options
 
         [Option('m', "parallelismDegree", Required = false, Default = 10, HelpText = "Degree of Parallelism")]
         public int ParallelismDegree { get; set; }
+
+        [Option('l', "listOfImagesPath", Required = false, SetName = "ImagesListPath", HelpText = "The path of images list file")]
+        public string ImagesListFilePath { get; set; }
     }
 }

--- a/src/cli/options/TrivyOptions.cs
+++ b/src/cli/options/TrivyOptions.cs
@@ -11,13 +11,7 @@ namespace cli.options
         [Option('a', "trivyCachePath", Required = false, HelpText = "Folder path of Trivy cache files")]
         public string TrivyCachePath { get; set; }
 
-        [Option('c', "containerRegistryAddress", Required = false, HelpText = "Container Registry Address")]
-        public string ContainerRegistryAddress { get; set; }
-
-        [Option('u', "containerRegistryUserName", Required = false, HelpText = "Container Registry User Name")]
-        public string ContainerRegistryUserName { get; set; }
-
-        [Option('p', "containerRegistryPassword", Required = false, HelpText = "Container Registry User Password")]
-        public string ContainerRegistryPassword { get; set; }
+        [Option('r', "registries", Required = false, HelpText = "The path of Container Registry Credentials file")]
+        public string RegistriesFilePath { get; set; }
     }
 }

--- a/src/core/exporters/FileExporter.cs
+++ b/src/core/exporters/FileExporter.cs
@@ -21,20 +21,18 @@ namespace core.exporters
             // if folder path is not provided, use default folder
             if (string.IsNullOrEmpty(folderPath))
             {
-                this.folderPath = Path.Combine(
+                folderPath = Path.Combine(
                     Environment.GetFolderPath(Environment.SpecialFolder.Personal),
                     ".image-scanner",
                     "exports");
-            }
-            else
-            {
-                this.folderPath = folderPath;
             }
 
             if (!Directory.Exists(folderPath))
             {
                 Directory.CreateDirectory(folderPath);
             }
+
+            this.folderPath = folderPath;
         }
 
         public async Task UploadAsync(ImageScanDetails details)

--- a/src/core/scanners/Trivy.cs
+++ b/src/core/scanners/Trivy.cs
@@ -50,7 +50,22 @@ namespace core.scanners
             this.cachePath = cachePath;
             this.trivyBinaryPath = trivyBinaryPath;
 
-            this.registriesMap = registries.ToDictionary(i => i.Name);
+            var map = new Dictionary<string, RegistryCredentials>();
+
+            foreach (var r in registries)
+            {
+                if (r is null)
+                {
+                    continue;
+                }
+
+                if (!map.ContainsKey(r.Name))
+                {
+                    map.Add(r.Name, r);
+                }
+            }
+
+            this.registriesMap = map;
         }
 
         public async Task<ImageScanDetails> Scan(ContainerImage image)

--- a/src/core/scanners/Trivy.cs
+++ b/src/core/scanners/Trivy.cs
@@ -50,22 +50,14 @@ namespace core.scanners
             this.cachePath = cachePath;
             this.trivyBinaryPath = trivyBinaryPath;
 
-            var map = new Dictionary<string, RegistryCredentials>();
+            this.registriesMap = new Dictionary<string, RegistryCredentials>();
 
-            foreach (var r in registries)
+            // != null verification is safety check against corrupted yaml configurations
+            foreach (var r in registries.Where(i => i != null))
             {
-                if (r is null)
-                {
-                    continue;
-                }
-
-                if (!map.ContainsKey(r.Name))
-                {
-                    map.Add(r.Name, r);
-                }
+                // TryAdd inserts new element to dictionary only if Key is a new entry
+                this.registriesMap.TryAdd(r.Name, r);
             }
-
-            this.registriesMap = map;
         }
 
         public async Task<ImageScanDetails> Scan(ContainerImage image)


### PR DESCRIPTION
- fix an issue that causes the CLI project unexpectedly finishes without giving any error
- make changes to work when no container registries provided
- support multiple container-registry credentials
- scan a list of tags (not only k8s cluster)
- make `KubeConfigPath` and `listOfImagesPath` CLI options mutually exclusive
- fix a minor issue in `FileExporter.cs` file

issue #1  