### PR TITLE
fix: return human-readable trivy error descriptions

### DIFF
--- a/src/tests/TrivyScanDescriptionNormalizerTests.cs
+++ b/src/tests/TrivyScanDescriptionNormalizerTests.cs
@@ -1,0 +1,55 @@
+﻿using System;
+
+using FluentAssertions;
+
+using NUnit.Framework;
+
+using webapp.Models;
+
+namespace tests
+{
+    [TestFixture]
+    public class TrivyScanDescriptionNormalizerTests
+    {
+        [Test]
+        public void NotAuthorized()
+        {
+            var sampleNotAuthorized = @"
+\u001b[0m\terror in image scan: failed to analyze image: failed to extract files: failed to create the registry client: Get https://aksrepos.azurecr.io/v2/: http: non-successful response (status=401 body=""{\""errors\"":[{\""code\"":\""UNAUTHORIZED\"",\""message\"":\""authentication required\"",\""detail\"":null}]}\n"")";
+
+            var actualResponse = TrivyScanDescriptionNormalizer.ToHumanReadable(sampleNotAuthorized);
+
+            actualResponse.Should().Be(TrivyScanDescriptionNormalizer.NotAuthorized);
+        }
+
+        [Test]
+        public void UnknownOS()
+        {
+            var sampleNotAuthorized = @"\u001b[0m\terror in image scan: failed to scan image: failed to analyze OS: Unknown OS";
+
+            var actualResponse = TrivyScanDescriptionNormalizer.ToHumanReadable(sampleNotAuthorized);
+
+            actualResponse.Should().Be(TrivyScanDescriptionNormalizer.UnknownOS);
+        }
+
+        [Test]
+        public void UnknownError()
+        {
+            var sampleNotAuthorized = @"\u001b[0m\terror in image scan: failed to analyze image: failed to extract files: failed to extract files: failed to extract the archive: unexpected EOF";
+
+            var actualResponse = TrivyScanDescriptionNormalizer.ToHumanReadable(sampleNotAuthorized);
+
+            actualResponse.Should().Be(TrivyScanDescriptionNormalizer.UnknownError);
+        }
+
+        [Test]
+        public void RandomText()
+        {
+            var sampleNotAuthorized = Guid.NewGuid().ToString();
+
+            var actualResponse = TrivyScanDescriptionNormalizer.ToHumanReadable(sampleNotAuthorized);
+
+            actualResponse.Should().Be(TrivyScanDescriptionNormalizer.UnknownError);
+        }
+    }
+}

--- a/src/webapp/Controllers/ScanResultsController.cs
+++ b/src/webapp/Controllers/ScanResultsController.cs
@@ -125,7 +125,7 @@ namespace webapp.Controllers
                     {
                         Image = containerImage.FullName,
                         ScanResult = result.ScanResult,
-                        Description = result.Payload,
+                        Description = TrivyScanDescriptionNormalizer.ToHumanReadable(result.Payload),
                     });
             }
             else

--- a/src/webapp/Models/TrivyScanDescriptionNormalizer.cs
+++ b/src/webapp/Models/TrivyScanDescriptionNormalizer.cs
@@ -1,0 +1,44 @@
+﻿namespace webapp.Models
+{
+    /// <summary>
+    /// The object normalizes trivy output.
+    /// </summary>
+    public static class TrivyScanDescriptionNormalizer
+    {
+        /// <summary>
+        /// Human-friendly not-authorized message.
+        /// </summary>
+        public const string NotAuthorized = "Trivy is not authorized to pull the image";
+
+        /// <summary>
+        /// Human-friendly Unknown-OS message.
+        /// </summary>
+        public const string UnknownOS = "Trivy is not able to scan underlying OS";
+
+        /// <summary>
+        /// Human-friendly Unknown-Error message.
+        /// </summary>
+        public const string UnknownError = "Unknown error occured";
+
+        /// <summary>
+        /// Converts trivy output to human-friendly text.
+        /// </summary>
+        /// <param name="description">Trivy scan output.</param>
+        /// <returns>Human readable result description.</returns>
+        public static string ToHumanReadable(string description)
+        {
+            if (description.Contains("status=401"))
+            {
+                return NotAuthorized;
+            }
+            else if (description.Contains("failed to analyze OS: Unknown OS"))
+            {
+                return UnknownOS;
+            }
+            else
+            {
+                return UnknownError;
+            }
+        }
+    }
+}

--- a/src/webapp/webapp.xml
+++ b/src/webapp/webapp.xml
@@ -277,6 +277,33 @@
             Indicates if service requires a restart.
             </summary>
         </member>
+        <member name="T:webapp.Models.TrivyScanDescriptionNormalizer">
+            <summary>
+            The object normalizes trivy output.
+            </summary>
+        </member>
+        <member name="F:webapp.Models.TrivyScanDescriptionNormalizer.NotAuthorized">
+            <summary>
+            Human-friendly not-authorized message.
+            </summary>
+        </member>
+        <member name="F:webapp.Models.TrivyScanDescriptionNormalizer.UnknownOS">
+            <summary>
+            Human-friendly Unknown-OS message.
+            </summary>
+        </member>
+        <member name="F:webapp.Models.TrivyScanDescriptionNormalizer.UnknownError">
+            <summary>
+            Human-friendly Unknown-Error message.
+            </summary>
+        </member>
+        <member name="M:webapp.Models.TrivyScanDescriptionNormalizer.ToHumanReadable(System.String)">
+            <summary>
+            Converts trivy output to human-friendly text.
+            </summary>
+            <param name="description">Trivy scan output.</param>
+            <returns>Human readable result description.</returns>
+        </member>
         <member name="T:webapp.Models.TrivyScanResultFull">
             <summary>
             Represents detailed information about a single Trivy Scan Result.


### PR DESCRIPTION
**What this PR does / why we need it**:

In case of failed scans, instead plain trivy output, return human-readable messages

**Which issue(s) this PR fixes**:

Fixes #21

**Does this PR introduce a user-facing change?**:

The single-scan-result page would display these messages